### PR TITLE
Updating to ROOT v6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,14 +86,6 @@ install(FILES
   "${PROJECT_BINARY_DIR}/alberscoreConfigVersion.cmake"
   DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
 
-# Install the pcm dictionaries along with the libraries
-if (${ROOT_VERSION} GREATER 6)
-  install(FILES
-    "${PROJECT_BINARY_DIR}/albers/AlbersDict_rdict.pcm"
-    "${PROJECT_BINARY_DIR}/datamodel/ExampleDataModelDict_rdict.pcm"
-    DESTINATION "${INSTALL_LIB_DIR}" COMPONENT dev)
-endif()
-
 # Install the export set for use with the install-tree
 install(EXPORT alberscoreTargets DESTINATION
   "${INSTALL_CMAKE_DIR}" COMPONENT dev)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ install(FILES
 if (${ROOT_VERSION} GREATER 6)
   install(FILES
     "${PROJECT_BINARY_DIR}/albers/AlbersDict_rdict.pcm"
-    "${PROJECT_BINARY_DIR}/datamodel/ExampleDict_rdict.pcm"
+    "${PROJECT_BINARY_DIR}/datamodel/ExampleDataModelDict_rdict.pcm"
     DESTINATION "${INSTALL_LIB_DIR}" COMPONENT dev)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,10 @@ find_package(ROOT)
 
 # set up include-directories
 include_directories(
-  "${PROJECT_SOURCE_DIR}"   
+  "${PROJECT_SOURCE_DIR}"
   "${PROJECT_BINARY_DIR}"
   "${ROOT_INCLUDE_DIR}"
-  )  
+  )
 
 # Add sub-directories
 add_subdirectory(albers)
@@ -85,6 +85,14 @@ install(FILES
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/alberscoreConfig.cmake"
   "${PROJECT_BINARY_DIR}/alberscoreConfigVersion.cmake"
   DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
+
+# Install the pcm dictionaries along with the libraries
+if (${ROOT_VERSION} GREATER 6)
+  install(FILES
+    "${PROJECT_BINARY_DIR}/albers/AlbersDict_rdict.pcm"
+    "${PROJECT_BINARY_DIR}/datamodel/ExampleDict_rdict.pcm"
+    DESTINATION "${INSTALL_LIB_DIR}" COMPONENT dev)
+endif()
 
 # Install the export set for use with the install-tree
 install(EXPORT alberscoreTargets DESTINATION

--- a/albers/CMakeLists.txt
+++ b/albers/CMakeLists.txt
@@ -22,3 +22,10 @@ install(TARGETS albers
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT shlib
   PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDE_DIR}/albers"
     COMPONENT dev)
+
+# Install the pcm dictionaries along with the libraries
+if (${ROOT_VERSION} GREATER 6)
+  install(FILES
+    "${PROJECT_BINARY_DIR}/albers/AlbersDict_rdict.pcm"
+    DESTINATION "${INSTALL_LIB_DIR}" COMPONENT dev)
+endif()

--- a/datamodel/CMakeLists.txt
+++ b/datamodel/CMakeLists.txt
@@ -6,9 +6,9 @@ include_directories(
 file(GLOB sources src/*.cc datamodel/*.h)
 file(GLOB headers datamodel/*.h albers/PyEventStore.h)
 
-ROOT_GENERATE_DICTIONARY(ExampleDict datamodel/*.h albers/PyEventStore.h LINKDEF LinkDef.h )
+ROOT_GENERATE_DICTIONARY(ExampleDataModelDict datamodel/*.h albers/PyEventStore.h LINKDEF LinkDef.h )
 
-add_library(exampledatamodel SHARED ${sources} ${}ExampleDict.cxx)
+add_library(exampledatamodel SHARED ${sources} ${}ExampleDataModelDict.cxx)
 target_link_libraries(exampledatamodel albers ${ROOT_LIBRARIES} ${ROOT_COMPONENT_LIBRARIES})
 
 # set_target_properties(datamodel PROPERTIES

--- a/datamodel/CMakeLists.txt
+++ b/datamodel/CMakeLists.txt
@@ -21,3 +21,9 @@ install(TARGETS exampledatamodel
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT shlib
   PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDE_DIR}/datamodel"
     COMPONENT dev)
+
+if (${ROOT_VERSION} GREATER 6)
+  install(FILES
+      "${PROJECT_BINARY_DIR}/datamodel/ExampleDataModelDict_rdict.pcm"
+      DESTINATION "${INSTALL_LIB_DIR}" COMPONENT dev)
+endif()

--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,6 @@
 export PATH=/afs/cern.ch/sw/lcg/contrib/CMake/2.8.9/Linux-i386/bin:${PATH}
 source /afs/cern.ch/sw/lcg/contrib/gcc/4.9.3/x86_64-slc6/setup.sh
-source /afs/cern.ch/sw/lcg/releases/ROOT/6.04.06-458fa/x86_64-slc6-gcc49-opt/bin/thisroot.sh
+source /afs/cern.ch/exp/fcc/sw/0.5/LCG_80/ROOT/6.04.06/x86_64-slc6-gcc49-opt/bin/thisroot.sh
 
 export ALBERS=$PWD/install
 export LD_LIBRARY_PATH=$ALBERS/examples:$ALBERS/lib:$LD_LIBRARY_PATH

--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,6 @@
 export PATH=/afs/cern.ch/sw/lcg/contrib/CMake/2.8.9/Linux-i386/bin:${PATH}
-source /afs/cern.ch/sw/lcg/contrib/gcc/4.8.1/x86_64-slc6/setup.sh
-source /afs/cern.ch/sw/lcg/app/releases/ROOT/5.34.20/x86_64-slc6-gcc48-opt/root/bin/thisroot.sh
+source /afs/cern.ch/sw/lcg/contrib/gcc/4.9.3/x86_64-slc6/setup.sh
+source /afs/cern.ch/sw/lcg/releases/ROOT/6.04.06-458fa/x86_64-slc6-gcc49-opt/bin/thisroot.sh
 
 export ALBERS=$PWD/install
 export LD_LIBRARY_PATH=$ALBERS/examples:$ALBERS/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
Updated the init.sh script to use GCC / ROOT versions as used currently in FCCSW. Also added the newly generated PCM dictionaries as install targets (with a check on the detected ROOT version).