### PR TITLE
Remove unnecessary dependency that forces recompilation.

### DIFF
--- a/cmake/FindROOT.cmake
+++ b/cmake/FindROOT.cmake
@@ -90,7 +90,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     unset(linkFile CACHE)
   endforeach()
   #---call rootcint------------------------------------------
-  add_custom_command(OUTPUT ${dictionary}.cxx ${dictionary}.h
+  add_custom_command(OUTPUT ${dictionary}.cxx 
                      COMMAND ${ROOTCINT_EXECUTABLE} -cint -f  ${dictionary}.cxx 
                                           -c ${ARG_OPTIONS} ${includedirs} ${headerfiles} ${linkdefs} 
                      DEPENDS ${headerfiles} ${linkdefs} VERBATIM)


### PR DESCRIPTION
Currently the dictionaries are recompiled on every invocation of ``make``, regardless of change. The build system apparently expects a ``*Dict.h`` file that is never generated. But it seems to be easily fixed (see https://sft.its.cern.ch/jira/browse/ROOT-7039).